### PR TITLE
Build MVLU preview site for M1 story-driven learning

### DIFF
--- a/assets/m1-panels.json
+++ b/assets/m1-panels.json
@@ -1,0 +1,190 @@
+{
+  "module": "M1",
+  "title": "昨夜的证词",
+  "subtitle": "Past Simple Q&A • 外研社五上 M1",
+  "panels": [
+    {
+      "id": "P01",
+      "sceneTitle": "情绪博物馆·夜色入口",
+      "tierI": {
+        "sceneDescription": "夜幕下的情绪博物馆被雨后薄雾环绕，湿润的石板路反射出金色灯光。珍珍背着渐变紫色的背包，牵着发光的蜜桃兔挂件，正与穿制服的夜巡守卫对话。",
+        "chineseDialogue": "珍珍喘着气说明来意，守卫举起光幕询问：\"昨夜到底发生了什么？\""
+      },
+      "tierII": {
+        "englishLine": "Did you [[see]] anyone enter the gallery [[yesterday]]?",
+        "translation": "你昨天看到有人进入展厅了吗？",
+        "wordCards": [
+          {
+            "word": "see",
+            "ipa": "/siː/",
+            "translation": "看见",
+            "examples": [
+              "I see the lights from here.",
+              "Did you see the magic creature?"
+            ]
+          },
+          {
+            "word": "yesterday",
+            "ipa": "/ˈjɛstərdeɪ/",
+            "translation": "昨天",
+            "examples": [
+              "We studied verbs yesterday.",
+              "She called me yesterday evening."
+            ]
+          }
+        ]
+      },
+      "tierIII": {
+        "spellName": "Inquiry Beam",
+        "spellTagline": "Did + 主语 + 动词原形?",
+        "effect": "Q版珍珍举起星辉麦克风，发射蓝金色询问光束，将疑影守卫的怀疑符文一一照亮。"
+      },
+      "tierIV": {
+        "methodTitle": "过去时三板斧 · 第一步",
+        "bullets": [
+          "Step 1: 用 Did 打开时光门",
+          "Step 2: 主语紧跟不变身",
+          "Step 3: 动词保持原形，时间词收尾"
+        ]
+      },
+      "tierV": {
+        "mrd7": {
+          "dimension": "韧性黄",
+          "progress": 15,
+          "note": "敢于发问，心灵彩虹亮度 +15%"
+        },
+        "ugcTask": {
+          "title": "UGC 预告",
+          "prompt": "写下你昨天鼓起勇气问出的一个问题。",
+          "tip": "用句型 Did you... yesterday?"
+        }
+      },
+      "visualPrompt": "现代动漫·暖金主光与冷蓝轮廓，珍珍 7 头身，短发右侧内卷，紫粉连衣裙配玻璃心灵彩虹。"
+    },
+    {
+      "id": "P02",
+      "sceneTitle": "记忆甬道·银色回声",
+      "tierI": {
+        "sceneDescription": "漫长的回声走廊里漂浮着光之档案。珍珍触摸一片记忆玻璃，画面中出现匆匆跑过的少年影子，手里握着闪闪发亮的银钥匙。",
+        "chineseDialogue": "记忆碎片闪现，蜜桃兔轻轻跃起指向倒地的钥匙。"
+      },
+      "tierII": {
+        "englishLine": "I [[saw]] a shadow boy drop a silver [[key]].",
+        "translation": "我看见一个影子男孩掉下了一把银色的钥匙。",
+        "wordCards": [
+          {
+            "word": "saw",
+            "ipa": "/sɔː/",
+            "translation": "看见（see 的过去式）",
+            "examples": [
+              "I saw the comet last night.",
+              "She saw a friend at the museum."
+            ]
+          },
+          {
+            "word": "key",
+            "ipa": "/kiː/",
+            "translation": "钥匙",
+            "examples": [
+              "This key opens the door.",
+              "Keep the key in your pocket."
+            ]
+          }
+        ]
+      },
+      "tierIII": {
+        "spellName": "Chrono Slash",
+        "spellTagline": "主语 + V2 + ...",
+        "effect": "Q版珍珍挥动时间羽刃，切开昨夜的影像，亮起 saw 的过去式符号，让证据凝固成光。"
+      },
+      "tierIV": {
+        "methodTitle": "过去时三板斧 · 第二步",
+        "bullets": [
+          "Step 1: 找到动作的 V2 形态",
+          "Step 2: 放进 I/He/She 后面",
+          "Step 3: 用时间副词锁定昨夜"
+        ]
+      },
+      "tierV": {
+        "mrd7": {
+          "dimension": "洞察蓝",
+          "progress": 20,
+          "note": "复述证词，洞察力 +20%"
+        },
+        "ugcTask": {
+          "title": "任务提示",
+          "prompt": "描述你昨天看见的一件细节。",
+          "tip": "开头试试：I saw..."
+        }
+      },
+      "visualPrompt": "玻璃长廊充满漂浮档案，冷蓝与银白色调，Q版珍珍在侧面板挥动时间羽刃。"
+    },
+    {
+      "id": "P03",
+      "sceneTitle": "证词大厅·光羽宣誓",
+      "tierI": {
+        "sceneDescription": "巨大的宣誓厅中央悬挂着心灵彩虹仪，守卫记录着珍珍的证词。光束照在珍珍坚定的脸庞，观测席上的灵光观众低声议论。",
+        "chineseDialogue": "守卫点头：\"有了证词，我们可以开启昨夜的心灵录像了。\""
+      },
+      "tierII": {
+        "englishLine": "He [[picked]] it up and [[gave]] it to the night [[guide]].",
+        "translation": "他捡起钥匙并把它交给了夜行向导。",
+        "wordCards": [
+          {
+            "word": "picked",
+            "ipa": "/pɪkt/",
+            "translation": "捡起（pick 的过去式）",
+            "examples": [
+              "She picked a flower.",
+              "I picked up the phone yesterday."
+            ]
+          },
+          {
+            "word": "gave",
+            "ipa": "/ɡeɪv/",
+            "translation": "给（give 的过去式）",
+            "examples": [
+              "He gave me a map.",
+              "We gave the ticket to the guard."
+            ]
+          },
+          {
+            "word": "guide",
+            "ipa": "/ɡaɪd/",
+            "translation": "向导",
+            "examples": [
+              "The guide showed us the hall.",
+              "Ask the guide for help."
+            ]
+          }
+        ]
+      },
+      "tierIII": {
+        "spellName": "Tri-Ed Sigil",
+        "spellTagline": "规则动词 +ed 三读，V2 不规则对照",
+        "effect": "Q版珍珍召唤三重发音符阵，/t/、/d/、/ɪd/ 依次亮起，同时给 gave 显示特殊紫光。"
+      },
+      "tierIV": {
+        "methodTitle": "过去时三板斧 · 第三步",
+        "bullets": [
+          "Step 1: -ed 读 /t/、/d/ 或 /ɪd/",
+          "Step 2: 不规则动词背发光卡",
+          "Step 3: 证词结尾强调动作结果"
+        ]
+      },
+      "tierV": {
+        "mrd7": {
+          "dimension": "表达橙",
+          "progress": 25,
+          "note": "完整陈述，表达力 +25%"
+        },
+        "ugcTask": {
+          "title": "挑战卡",
+          "prompt": "续写昨夜故事：再说一个他做的动作。",
+          "tip": "句型提示：He/She + V2..."
+        }
+      },
+      "visualPrompt": "宣誓厅金色主光配冷蓝轮廓，心灵彩虹仪悬浮，Q版珍珍在魔法面板上释放三重发音符阵。"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,913 +1,746 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>妈妈，请停下"调理"的手 | 你的爱正在伤害孩子</title>
-    <meta name="description" content="揭示'调理脾胃'背后的真相：你的限制性喂养正在偷走孩子的智力、健康和未来。立即了解科学喂养方法。">
-    <meta name="keywords" content="调理脾胃,儿童营养,喂养误区,孩子瘦小,营养不良,科学育儿">
-    
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-    
-    <style>
-        :root {
-            --bg-dark: #111827;
-            --text-light: #e5e7eb;
-            --text-secondary: #9ca3af;
-            --primary-orange: #f97316;
-            --danger-red: #ef4444;
-            --success-green: #22c55e;
-            --accent-blue: #38bdf8;
-            --accent-purple: #a855f7;
-        }
-        
-        html { scroll-behavior: smooth; }
-        
-        body {
-            font-family: 'Noto Sans SC', sans-serif;
-            background-color: var(--bg-dark);
-            color: var(--text-light);
-            line-height: 1.6;
-        }
-        
-        /* 淡入动画 */
-        .fade-in {
-            opacity: 0;
-            transform: translateY(30px);
-            transition: opacity 0.8s ease-out, transform 0.8s ease-out;
-        }
-        
-        .fade-in.visible {
-            opacity: 1;
-            transform: translateY(0);
-        }
-        
-        /* 卡片样式 */
-        .glass-card {
-            background: rgba(255, 255, 255, 0.03);
-            backdrop-filter: blur(10px);
-            border: 1px solid rgba(255, 255, 255, 0.1);
-            border-radius: 12px;
-            padding: 1.5rem;
-        }
-        
-        /* 叙述者卡片 */
-        .narrator-card {
-            background: rgba(249, 115, 22, 0.1);
-            border-left: 4px solid var(--primary-orange);
-            padding: 1.5rem;
-            margin: 2rem 0;
-            border-radius: 0 8px 8px 0;
-        }
-        
-        /* 高亮文本 */
-        .highlight {
-            background-color: var(--primary-orange);
-            color: white;
-            padding: 0.1rem 0.5rem;
-            border-radius: 3px;
-            font-weight: 700;
-        }
-        
-        /* 危害卡片 */
-        .harm-card {
-            background: rgba(239, 68, 68, 0.1);
-            border: 2px solid rgba(239, 68, 68, 0.3);
-            border-radius: 12px;
-            padding: 1.5rem;
-            position: relative;
-            overflow: hidden;
-        }
-        
-        .harm-card::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 4px;
-            background: var(--danger-red);
-            animation: pulse 2s ease-in-out infinite;
-        }
-        
-        @keyframes pulse {
-            0%, 100% { opacity: 0.6; }
-            50% { opacity: 1; }
-        }
-        
-        /* 致命闭环动画 */
-        .vortex {
-            animation: rotate 20s linear infinite;
-        }
-        
-        @keyframes rotate {
-            from { transform: rotate(0deg); }
-            to { transform: rotate(360deg); }
-        }
-        
-        /* 按钮样式 */
-        .btn-primary {
-            background: linear-gradient(135deg, var(--accent-blue) 0%, var(--accent-purple) 100%);
-            color: white;
-            padding: 0.75rem 2rem;
-            border-radius: 8px;
-            font-weight: 700;
-            transition: transform 0.2s, box-shadow 0.2s;
-            display: inline-block;
-            text-decoration: none;
-            border: none;
-            cursor: pointer;
-        }
-        
-        .btn-primary:hover {
-            transform: scale(1.05);
-            box-shadow: 0 10px 20px rgba(56, 189, 248, 0.3);
-        }
-        
-        /* 加载动画 */
-        .loader {
-            border: 3px solid rgba(255, 255, 255, 0.1);
-            border-top: 3px solid var(--primary-orange);
-            border-radius: 50%;
-            width: 40px;
-            height: 40px;
-            animation: spin 1s linear infinite;
-            margin: 1rem auto;
-        }
-        
-        @keyframes spin {
-            0% { transform: rotate(0deg); }
-            100% { transform: rotate(360deg); }
-        }
-        
-        /* 响应式图片 */
-        .hero-image {
-            max-width: 100%;
-            height: auto;
-            border-radius: 12px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
-        }
-        
-        /* 移动端优化 */
-        @media (max-width: 768px) {
-            .section-padding {
-                padding: 3rem 1rem;
-            }
-            
-            h1 {
-                font-size: 2rem;
-            }
-            
-            h2 {
-                font-size: 1.5rem;
-            }
-        }
-    </style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>故事驱动学习 MVP · M1《昨夜的证词》预览站</title>
+  <meta name="description" content="基于 MVLU 五层结构的故事驱动学习 MVP 预览，展示 M1《昨夜的证词》前三个分镜的内容 JSON 契约与交互基线。" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Noto+Sans+SC:wght@400;500;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --bg-dark: #0f172a;
+      --bg-panel: rgba(15, 23, 42, 0.85);
+      --glass: rgba(255, 255, 255, 0.12);
+      --primary: #8b5cf6;
+      --accent: #38bdf8;
+      --gold: #fbbf24;
+      --lime: #bef264;
+      --text-main: #e2e8f0;
+      --text-sub: #94a3b8;
+      --shadow: 0 24px 60px rgba(15, 23, 42, 0.45);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Noto Sans SC', 'Nunito', sans-serif;
+      background: radial-gradient(circle at top, #1e293b 0%, #020617 60%);
+      color: var(--text-main);
+      overflow-x: hidden;
+    }
+
+    header {
+      padding: 64px 5vw 32px;
+      position: relative;
+    }
+
+    header::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 20% -10%, rgba(139, 92, 246, 0.4), transparent 55%),
+        radial-gradient(circle at 80% 0%, rgba(56, 189, 248, 0.35), transparent 50%);
+      filter: blur(60px);
+      z-index: -1;
+    }
+
+    h1 {
+      font-size: clamp(2.2rem, 5vw, 3.4rem);
+      margin: 0 0 16px;
+      font-weight: 800;
+      letter-spacing: 0.03em;
+    }
+
+    .tagline {
+      font-size: 1.1rem;
+      color: var(--text-sub);
+      max-width: 680px;
+      line-height: 1.7;
+    }
+
+    .metrics-bar {
+      margin-top: 32px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+    }
+
+    .metric {
+      flex: 1 1 220px;
+      background: linear-gradient(135deg, rgba(139, 92, 246, 0.2), rgba(56, 189, 248, 0.08));
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      border-radius: 18px;
+      padding: 20px 24px;
+      backdrop-filter: blur(12px);
+      box-shadow: var(--shadow);
+    }
+
+    .metric h3 {
+      margin: 0 0 8px;
+      font-size: 0.95rem;
+      letter-spacing: 0.08em;
+      color: var(--text-sub);
+      text-transform: uppercase;
+    }
+
+    .metric strong {
+      font-size: 1.5rem;
+      color: var(--text-main);
+    }
+
+    main {
+      padding: 16px 5vw 120px;
+    }
+
+    .panel {
+      margin: 48px auto;
+      padding: clamp(24px, 4vw, 32px);
+      max-width: 960px;
+      border-radius: 32px;
+      background: linear-gradient(160deg, rgba(15, 23, 42, 0.88), rgba(30, 58, 138, 0.72));
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      box-shadow: var(--shadow);
+      display: grid;
+      gap: 24px;
+    }
+
+    .fade-in {
+      opacity: 0;
+      transform: translateY(40px);
+      transition: opacity 0.8s ease, transform 0.8s ease;
+    }
+
+    .fade-in.visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .panel-header {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .panel-header span {
+      font-size: 0.85rem;
+      color: var(--text-sub);
+      letter-spacing: 0.08em;
+    }
+
+    .scene-title {
+      font-size: 1.6rem;
+      font-weight: 700;
+    }
+
+    .tier-grid {
+      display: grid;
+      gap: 20px;
+    }
+
+    .tier-card {
+      position: relative;
+      padding: 20px 22px 22px;
+      border-radius: 24px;
+      background: rgba(15, 23, 42, 0.6);
+      border: 1px solid rgba(148, 163, 184, 0.22);
+      backdrop-filter: blur(8px);
+    }
+
+    .tier-card h4 {
+      margin: 0 0 12px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      font-size: 0.9rem;
+      color: var(--accent);
+    }
+
+    .narrative-canvas {
+      border-radius: 20px;
+      overflow: hidden;
+      position: relative;
+      height: 0;
+      padding-bottom: calc(16 / 9 * 100%);
+      background: linear-gradient(180deg, rgba(251, 191, 36, 0.18), rgba(14, 165, 233, 0.08));
+      border: 1px solid rgba(251, 191, 36, 0.35);
+    }
+
+    .narrative-canvas::after {
+      content: "9 : 16";
+      position: absolute;
+      right: 12px;
+      bottom: 12px;
+      font-size: 0.75rem;
+      color: rgba(255, 255, 255, 0.6);
+      letter-spacing: 0.08em;
+    }
+
+    .narrative-overlay {
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 30% 30%, rgba(248, 250, 252, 0.32), transparent 55%),
+        radial-gradient(circle at 80% 80%, rgba(14, 165, 233, 0.18), transparent 50%);
+      pointer-events: none;
+    }
+
+    .dialogue-line {
+      font-size: 1.2rem;
+      line-height: 1.8;
+      padding: 18px 20px;
+      border-radius: 18px;
+      background: rgba(56, 189, 248, 0.12);
+      border: 1px solid rgba(56, 189, 248, 0.35);
+      position: relative;
+    }
+
+    .dialogue-line span.word {
+      color: var(--gold);
+      font-weight: 700;
+      cursor: pointer;
+      position: relative;
+    }
+
+    .dialogue-line span.word::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      bottom: -4px;
+      width: 100%;
+      height: 2px;
+      background: linear-gradient(90deg, var(--gold), #f472b6);
+      opacity: 0.6;
+    }
+
+    .translation-hint {
+      margin-top: 10px;
+      font-size: 0.95rem;
+      color: rgba(226, 232, 240, 0.8);
+      background: rgba(15, 23, 42, 0.7);
+      border-radius: 14px;
+      padding: 12px 16px;
+      display: none;
+    }
+
+    .spell-area {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .cast-button {
+      background: radial-gradient(circle at 30% 20%, rgba(251, 191, 36, 0.9), rgba(139, 92, 246, 0.8));
+      border: none;
+      color: #0f172a;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      padding: 16px 24px;
+      border-radius: 999px;
+      box-shadow: 0 16px 28px rgba(251, 191, 36, 0.24);
+      cursor: pointer;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .cast-button::after {
+      content: "HOLD TO CAST";
+      position: absolute;
+      inset: 0;
+      display: grid;
+      place-items: center;
+      font-size: 0.75rem;
+      color: rgba(15, 23, 42, 0.8);
+      letter-spacing: 0.3em;
+    }
+
+    .cast-button span {
+      opacity: 0;
+    }
+
+    .spell-feedback {
+      display: none;
+      border-radius: 18px;
+      border: 1px solid rgba(139, 92, 246, 0.45);
+      padding: 16px 20px;
+      background: rgba(139, 92, 246, 0.16);
+      font-weight: 600;
+    }
+
+    .method-list {
+      display: grid;
+      gap: 10px;
+      margin: 0;
+      padding-left: 20px;
+      color: var(--text-sub);
+    }
+
+    .method-list li::marker {
+      color: var(--gold);
+    }
+
+    .badge-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+      align-items: center;
+    }
+
+    .badge {
+      padding: 12px 18px;
+      border-radius: 999px;
+      background: rgba(190, 242, 100, 0.15);
+      border: 1px solid rgba(190, 242, 100, 0.45);
+      color: var(--lime);
+      font-weight: 700;
+      letter-spacing: 0.06em;
+    }
+
+    .progress-bar {
+      height: 10px;
+      border-radius: 8px;
+      background: rgba(148, 163, 184, 0.25);
+      overflow: hidden;
+      margin-top: 8px;
+    }
+
+    .progress-bar span {
+      display: block;
+      height: 100%;
+      background: linear-gradient(90deg, #fbbf24, #fb7185);
+    }
+
+    .ugc-card {
+      padding: 18px;
+      border-radius: 18px;
+      border: 1px dashed rgba(148, 163, 184, 0.35);
+      background: rgba(15, 23, 42, 0.55);
+    }
+
+    .visual-prompt {
+      font-size: 0.9rem;
+      color: rgba(148, 163, 184, 0.7);
+      border-left: 3px solid rgba(139, 92, 246, 0.6);
+      padding-left: 12px;
+    }
+
+    .word-card-layer {
+      position: fixed;
+      inset: 0;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      background: rgba(2, 6, 23, 0.7);
+      z-index: 40;
+      padding: 20px;
+    }
+
+    .word-card {
+      width: min(420px, 90vw);
+      background: rgba(15, 23, 42, 0.95);
+      border-radius: 24px;
+      padding: 28px;
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      box-shadow: 0 40px 60px rgba(15, 23, 42, 0.6);
+    }
+
+    .word-card h3 {
+      margin: 0 0 4px;
+      font-size: 1.8rem;
+    }
+
+    .word-card .ipa {
+      font-size: 1rem;
+      color: var(--accent);
+      margin-bottom: 12px;
+    }
+
+    .word-card ul {
+      margin: 12px 0 0;
+      padding-left: 20px;
+      color: var(--text-sub);
+    }
+
+    .close-card {
+      background: transparent;
+      border: none;
+      color: rgba(226, 232, 240, 0.7);
+      font-size: 1.2rem;
+      cursor: pointer;
+      position: absolute;
+      top: 16px;
+      right: 20px;
+    }
+
+    footer {
+      padding: 48px 5vw 64px;
+      background: rgba(2, 6, 23, 0.65);
+      border-top: 1px solid rgba(148, 163, 184, 0.15);
+    }
+
+    footer h2 {
+      margin: 0 0 12px;
+      font-size: 1.4rem;
+    }
+
+    .metric-log {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 24px;
+      margin-top: 24px;
+      color: var(--text-sub);
+    }
+
+    .metric-log div {
+      flex: 1 1 180px;
+    }
+
+    @media (max-width: 768px) {
+      .panel {
+        margin: 32px auto;
+        padding: 20px;
+        border-radius: 24px;
+      }
+
+      .dialogue-line {
+        font-size: 1.05rem;
+      }
+    }
+  </style>
 </head>
 <body>
-    <!-- Section 1: 牙齿问题开篇 -->
-    <section class="section-padding py-20 px-6">
-        <div class="max-w-4xl mx-auto">
-            <div class="fade-in text-center mb-12">
-                <i class="fas fa-tooth text-6xl mb-6" style="color: var(--accent-blue);"></i>
-                <h1 class="text-4xl md:text-5xl font-black mb-6">
-                    妈妈，你发现了吗？
-                </h1>
-                <p class="text-xl text-secondary mb-8">
-                    现在的孩子，牙齿问题越来越多
-                </p>
-            </div>
-            
-            <div class="glass-card fade-in">
-                <p class="text-lg mb-4">
-                    我们给孩子的食物越来越精细，怕他们嚼不动、噎着...
-                </p>
-                <p class="text-lg mb-4">
-                    苹果切成小块，肉剁成肉糜，青菜切得碎碎的...
-                </p>
-                <p class="text-xl font-bold text-orange-400 mb-4">
-                    可是，孩子的牙齿却越来越不整齐，越来越容易蛀牙
-                </p>
-                <div class="narrator-card">
-                    <p class="text-lg">
-                        <i class="fas fa-lightbulb text-orange-400 mr-2"></i>
-                        <strong>牙医告诉我们：</strong>牙齿和颌骨需要通过咀嚼硬食物来锻炼！
-                        过度精细的食物让孩子的咀嚼功能退化了。
-                    </p>
-                </div>
-            </div>
-            
-            <div class="fade-in text-center mt-12">
-                <p class="text-2xl font-bold mb-8">
-                    这个简单的道理，我们都懂
-                </p>
-                <p class="text-3xl font-black text-orange-400">
-                    那么，妈妈...
-                </p>
-                <p class="text-2xl mt-6">
-                    你是否正在用同样的方式<br>
-                    <span class="text-4xl font-black text-red-400">废掉孩子的胃？</span>
-                </p>
-            </div>
+  <div class="word-card-layer" id="wordCardLayer" aria-hidden="true">
+    <div class="word-card" role="dialog" aria-modal="true">
+      <button class="close-card" aria-label="关闭词卡" id="closeCard">✕</button>
+      <h3 id="cardWord"></h3>
+      <div class="ipa" id="cardIpa"></div>
+      <div id="cardTranslation"></div>
+      <ul id="cardExamples"></ul>
+    </div>
+  </div>
+
+  <header>
+    <h1>故事驱动学习 MVP · M1《昨夜的证词》</h1>
+    <p class="tagline">
+      该预览站依据 MVLU 五层框架输出前三个分镜的标准化内容 JSON 契约，并以静态点击/长按/按钮交互模拟
+      NSE（有效开口次数）与 NSD（叙事沉浸度）指标，服务后续的流水线化制作与 GitHub Pages 发布。
+    </p>
+    <div class="metrics-bar" id="liveMetrics">
+      <div class="metric">
+        <h3>NSE · 有效开口</h3>
+        <strong id="metricSpeak">0</strong>
+        <div>Hold to Cast 或点击关键词计数</div>
+      </div>
+      <div class="metric">
+        <h3>NSD · 互动触达</h3>
+        <strong id="metricInteract">0</strong>
+        <div>对话长按、词卡等触发次数</div>
+      </div>
+      <div class="metric">
+        <h3>完读进度</h3>
+        <strong id="metricComplete">0%</strong>
+        <div>已浏览分镜 / 总分镜</div>
+      </div>
+    </div>
+  </header>
+
+  <main id="panelContainer" aria-live="polite"></main>
+
+  <footer>
+    <h2>内容生产下一步</h2>
+    <p>
+      · 扩展 P04-P12 的 JSON 契约字段，并补齐语音脚本与美术切片坐标。<br />
+      · 将词卡字段导出至 SRS 系统，与 MRD7 徽章联动。<br />
+      · 接入轻量埋点脚本，验证 NSE ≥ 8 句、NSD ≥ 3 次互动的达成率。
+    </p>
+    <div class="metric-log">
+      <div>GitHub Pages 部署：保持静态资源结构，assets/ 目录统一管理。</div>
+      <div>视觉提示：现代动漫赛璐璐 + 华丽光影，珍珍 7 头身锚点不可变。</div>
+      <div>教学基线：100% 对齐外研社五上 M1 过去时问答、陈述语块。</div>
+    </div>
+  </footer>
+
+  <script>
+    const panelContainer = document.getElementById('panelContainer');
+    const wordLayer = document.getElementById('wordCardLayer');
+    const closeCardBtn = document.getElementById('closeCard');
+    const cardWord = document.getElementById('cardWord');
+    const cardIpa = document.getElementById('cardIpa');
+    const cardTranslation = document.getElementById('cardTranslation');
+    const cardExamples = document.getElementById('cardExamples');
+
+    const metricSpeak = document.getElementById('metricSpeak');
+    const metricInteract = document.getElementById('metricInteract');
+    const metricComplete = document.getElementById('metricComplete');
+
+    const metrics = {
+      speak: 0,
+      interact: 0,
+      viewedPanels: new Set(),
+      totalPanels: 0
+    };
+
+    let holdTimer = null;
+
+    fetch('assets/m1-panels.json')
+      .then((res) => res.json())
+      .then((data) => {
+        metrics.totalPanels = data.panels.length;
+        data.panels.forEach((panel, index) => renderPanel(panel, index));
+        updateCompletion();
+      })
+      .catch((err) => {
+        panelContainer.innerHTML = `<p>无法加载内容契约：${err.message}</p>`;
+      });
+
+    function renderPanel(panel, index) {
+      const section = document.createElement('section');
+      section.className = 'panel fade-in';
+      section.id = panel.id;
+
+      const header = document.createElement('div');
+      header.className = 'panel-header';
+      header.innerHTML = `
+        <span>${panel.id} · MVLU Panel</span>
+        <div class="scene-title">${panel.sceneTitle}</div>
+        <div class="visual-prompt">${panel.visualPrompt}</div>
+      `;
+      section.appendChild(header);
+
+      const tierGrid = document.createElement('div');
+      tierGrid.className = 'tier-grid';
+
+      tierGrid.appendChild(createTierI(panel.tierI));
+      tierGrid.appendChild(createTierII(panel));
+      tierGrid.appendChild(createTierIII(panel));
+      tierGrid.appendChild(createTierIV(panel));
+      tierGrid.appendChild(createTierV(panel));
+
+      section.appendChild(tierGrid);
+      panelContainer.appendChild(section);
+
+      observeVisibility(section, panel.id);
+    }
+
+    function createTierI(tier) {
+      const card = document.createElement('div');
+      card.className = 'tier-card';
+      card.innerHTML = `
+        <h4>Tier I · 主叙事层</h4>
+        <div class="narrative-canvas">
+          <div class="narrative-overlay"></div>
         </div>
-    </section>
+        <p>${tier.sceneDescription}</p>
+        <p>${tier.chineseDialogue}</p>
+      `;
+      return card;
+    }
 
-    <!-- Section 2: 温室里的胃 -->
-    <section class="section-padding py-20 px-6 bg-gray-900">
-        <div class="max-w-4xl mx-auto">
-            <div class="fade-in text-center mb-12">
-                <h2 class="text-3xl md:text-4xl font-black mb-6">
-                    你正在打造一个<br>
-                    <span class="text-red-400">"温室里的胃"</span>
-                </h2>
-            </div>
-            
-            <div class="glass-card fade-in mb-8">
-                <div class="text-center mb-6">
-                    <i class="fas fa-seedling text-5xl text-green-400"></i>
-                </div>
-                <p class="text-lg mb-4">
-                    想象一下，如果你把一株小苗养在温室里，从不让它经历风雨...
-                </p>
-                <p class="text-lg mb-4">
-                    当有一天，你不得不把它移到室外时，会发生什么？
-                </p>
-                <p class="text-2xl font-black text-red-400 text-center">
-                    它会立刻枯萎！
-                </p>
-                <p class="text-lg mt-4">
-                    因为它从未学会如何适应真实的世界。
-                </p>
-            </div>
-            
-            <div class="narrator-card fade-in">
-                <p class="text-lg">
-                    <strong>孩子的胃，就是你正在培养的"温室植物"</strong>
-                </p>
-                <p class="mt-2">
-                    你给它的食物越单一、越"安全"，它的适应能力就越差。
-                    总有一天，孩子要离开你的保护，面对真实的食物世界。
-                </p>
-            </div>
-            
-            <div class="fade-in text-center mt-12">
-                <p class="text-xl mb-4">你是不是也这样？</p>
-                <div class="glass-card text-left">
-                    <p class="mb-3"><i class="fas fa-times text-red-400 mr-2"></i>西瓜太凉，不能吃</p>
-                    <p class="mb-3"><i class="fas fa-times text-red-400 mr-2"></i>香蕉滑肠，不能吃</p>
-                    <p class="mb-3"><i class="fas fa-times text-red-400 mr-2"></i>牛奶生痰，少喝</p>
-                    <p class="mb-3"><i class="fas fa-times text-red-400 mr-2"></i>肉类积食，一周最多两次</p>
-                    <p class="text-xl font-bold text-orange-400 mt-4">
-                        孩子的食物清单越来越短，而他却越来越瘦？
-                    </p>
-                </div>
-            </div>
+    function createTierII(panel) {
+      const card = document.createElement('div');
+      card.className = 'tier-card';
+      card.innerHTML = '<h4>Tier II · 交互对话层</h4>';
+
+      const dialogue = document.createElement('div');
+      dialogue.className = 'dialogue-line';
+      dialogue.innerHTML = highlightSentence(panel.tierII.englishLine, panel.tierII.wordCards);
+      dialogue.setAttribute('data-translation', panel.tierII.translation);
+      card.appendChild(dialogue);
+
+      const hint = document.createElement('div');
+      hint.className = 'translation-hint';
+      hint.textContent = panel.tierII.translation;
+      card.appendChild(hint);
+
+      attachLongPress(dialogue, hint);
+      attachWordCards(dialogue, panel.tierII.wordCards);
+
+      return card;
+    }
+
+    function createTierIII(panel) {
+      const card = document.createElement('div');
+      card.className = 'tier-card';
+      card.innerHTML = `
+        <h4>Tier III · 魔咒施法层</h4>
+        <div class="spell-area">
+          <button class="cast-button" data-spell="${panel.tierIII.spellName}"><span>${panel.tierIII.spellName}</span></button>
+          <div class="spell-feedback">
+            <strong>${panel.tierIII.spellName}</strong> · ${panel.tierIII.spellTagline}<br />
+            ${panel.tierIII.effect}
+          </div>
         </div>
-    </section>
+      `;
 
-    <!-- Section 3: 数据对比 -->
-    <section class="section-padding py-20 px-6">
-        <div class="max-w-6xl mx-auto">
-            <div class="fade-in text-center mb-12">
-                <h2 class="text-3xl md:text-4xl font-black mb-6">
-                    我们最讲究"养脾胃"<br>
-                    <span class="text-red-400">孩子却最瘦小？</span>
-                </h2>
-            </div>
-            
-            <div class="fade-in overflow-x-auto">
-                <table class="w-full glass-card">
-                    <thead>
-                        <tr class="border-b border-gray-700">
-                            <th class="p-4 text-left">国家</th>
-                            <th class="p-4 text-center">10岁儿童平均体重</th>
-                            <th class="p-4 text-center">饮食特点</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr class="border-b border-gray-800">
-                            <td class="p-4">🇺🇸 美国</td>
-                            <td class="p-4 text-center font-bold text-green-400">36.8 kg</td>
-                            <td class="p-4 text-center">食物多样，不忌口</td>
-                        </tr>
-                        <tr class="border-b border-gray-800">
-                            <td class="p-4">🇯🇵 日本</td>
-                            <td class="p-4 text-center font-bold text-green-400">34.2 kg</td>
-                            <td class="p-4 text-center">生冷海鲜随便吃</td>
-                        </tr>
-                        <tr class="border-b border-gray-800">
-                            <td class="p-4">🇰🇷 韩国</td>
-                            <td class="p-4 text-center font-bold text-green-400">35.5 kg</td>
-                            <td class="p-4 text-center">泡菜烤肉不限制</td>
-                        </tr>
-                        <tr class="bg-red-900/20">
-                            <td class="p-4">🇨🇳 中国</td>
-                            <td class="p-4 text-center font-bold text-red-400">33.7 kg</td>
-                            <td class="p-4 text-center font-bold">最讲究"调理脾胃"</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            
-            <div class="narrator-card fade-in mt-8 text-center">
-                <p class="text-xl font-bold">
-                    妈妈，是时候反思了...<br>
-                    我们付出了最多的"调理"，孩子却最瘦小？
-                </p>
-            </div>
-        </div>
-    </section>
+      const button = card.querySelector('.cast-button');
+      const feedback = card.querySelector('.spell-feedback');
 
-    <!-- Section 4: 三大伤害 -->
-    <section class="section-padding py-20 px-6 bg-black">
-        <div class="max-w-6xl mx-auto">
-            <div class="fade-in text-center mb-12">
-                <h2 class="text-3xl md:text-4xl font-black mb-6">
-                    限制性喂养的<br>
-                    <span class="text-red-400">三大不可逆伤害</span>
-                </h2>
-                <p class="text-xl text-secondary">正在你的"爱"中悄然发生</p>
-            </div>
-            
-            <div class="grid md:grid-cols-3 gap-6">
-                <div class="harm-card fade-in">
-                    <div class="text-center mb-4">
-                        <i class="fas fa-brain text-5xl text-red-400 mb-4"></i>
-                        <p class="text-6xl font-black text-red-400">-15</p>
-                        <p class="text-xl font-bold">智商永久损失</p>
-                    </div>
-                    <p class="text-sm">
-                        营养不良会导致大脑发育受阻。研究表明，儿童期蛋白质-热能营养不良
-                        <span class="highlight">可使智商降低15分</span>，
-                        而这种损失是永久性的！
-                    </p>
-                </div>
-                
-                <div class="harm-card fade-in" style="animation-delay: 0.2s;">
-                    <div class="text-center mb-4">
-                        <i class="fas fa-dna text-5xl text-purple-400 mb-4"></i>
-                        <p class="text-2xl font-black text-purple-400">DOHaD</p>
-                        <p class="text-xl font-bold">编程成年慢性病</p>
-                    </div>
-                    <p class="text-sm">
-                        生命早期营养不良会"编程"孩子的基因，
-                        <span class="highlight">让他们成年后患心血管疾病、糖尿病的风险增加3-5倍</span>。
-                    </p>
-                </div>
-                
-                <div class="harm-card fade-in" style="animation-delay: 0.4s;">
-                    <div class="text-center mb-4">
-                        <i class="fas fa-shield-virus text-5xl text-blue-400 mb-4"></i>
-                        <p class="text-6xl font-black text-blue-400">70%</p>
-                        <p class="text-xl font-bold">免疫系统在肠道</p>
-                    </div>
-                    <p class="text-sm">
-                        肠道是人体最大的免疫器官。过度"干净"的饮食让肠道菌群失调，
-                        <span class="highlight">孩子反而更容易生病</span>！
-                    </p>
-                </div>
-            </div>
-            
-            <div class="fade-in text-center mt-12">
-                <p class="text-2xl font-bold text-red-400">
-                    妈妈，这就是你想要的结果吗？
-                </p>
-            </div>
-        </div>
-    </section>
+      const triggerSpell = (strongCast = false) => {
+        metrics.speak += 1;
+        metrics.interact += 1;
+        updateMetrics();
+        feedback.style.display = 'block';
+        feedback.style.borderColor = strongCast ? 'rgba(251, 191, 36, 0.9)' : 'rgba(139, 92, 246, 0.45)';
+        feedback.style.background = strongCast
+          ? 'rgba(251, 191, 36, 0.25)'
+          : 'rgba(139, 92, 246, 0.16)';
+        feedback.innerHTML = `<strong>${panel.tierIII.spellName}</strong> · ${panel.tierIII.spellTagline}<br />${panel.tierIII.effect}<div style="margin-top:8px;color:var(--text-sub);">${
+          strongCast ? 'Perfect Cast! 光束强度 +30%' : 'Baseline Cast · 点击也算一次有效开口'
+        }</div>`;
+      };
 
-    <!-- Section 5: 戳穿谎言 -->
-    <section class="section-padding py-20 px-6">
-        <div class="max-w-4xl mx-auto">
-            <div class="fade-in text-center mb-12">
-                <h2 class="text-3xl md:text-4xl font-black mb-6">
-                    戳穿四大喂养谎言
-                </h2>
-            </div>
-            
-            <div class="space-y-6">
-                <div class="fade-in">
-                    <div class="glass-card bg-red-900/20 border-l-4 border-red-400">
-                        <p class="font-bold text-lg mb-2">
-                            <i class="fas fa-times-circle text-red-400 mr-2"></i>
-                            谎言："这个食物不好消化"
-                        </p>
-                        <p class="text-secondary">你以为在保护孩子的肠胃</p>
-                    </div>
-                    <div class="glass-card bg-green-900/20 border-l-4 border-green-400 mt-2">
-                        <p class="font-bold text-lg mb-2">
-                            <i class="fas fa-check-circle text-green-400 mr-2"></i>
-                            真相：消化能力需要锻炼！
-                        </p>
-                        <p>
-                            就像肌肉一样，<span class="highlight">用进废退</span>。
-                            你越是给孩子吃"好消化"的食物，他的消化能力就越弱！
-                        </p>
-                    </div>
-                </div>
-                
-                <div class="fade-in">
-                    <div class="glass-card bg-red-900/20 border-l-4 border-red-400">
-                        <p class="font-bold text-lg mb-2">
-                            <i class="fas fa-times-circle text-red-400 mr-2"></i>
-                            谎言："寒凉食物伤脾胃"
-                        </p>
-                        <p class="text-secondary">西瓜、香蕉都不敢给孩子吃</p>
-                    </div>
-                    <div class="glass-card bg-green-900/20 border-l-4 border-green-400 mt-2">
-                        <p class="font-bold text-lg mb-2">
-                            <i class="fas fa-check-circle text-green-400 mr-2"></i>
-                            真相：人体有强大的体温调节系统
-                        </p>
-                        <p>
-                            <span class="highlight">食物进入胃部很快就会被加热到体温</span>。
-                            日本孩子冬天吃冰淇淋，身体照样棒！
-                        </p>
-                    </div>
-                </div>
-                
-                <div class="fade-in">
-                    <div class="glass-card bg-red-900/20 border-l-4 border-red-400">
-                        <p class="font-bold text-lg mb-2">
-                            <i class="fas fa-times-circle text-red-400 mr-2"></i>
-                            谎言："上火的东西不能吃"
-                        </p>
-                        <p class="text-secondary">荔枝、芒果统统禁止</p>
-                    </div>
-                    <div class="glass-card bg-green-900/20 border-l-4 border-green-400 mt-2">
-                        <p class="font-bold text-lg mb-2">
-                            <i class="fas fa-check-circle text-green-400 mr-2"></i>
-                            真相："上火"多是维生素缺乏
-                        </p>
-                        <p>
-                            所谓"上火"症状，多数是<span class="highlight">B族维生素缺乏</span>导致的。
-                            限制饮食反而加重维生素缺乏！
-                        </p>
-                    </div>
-                </div>
-                
-                <div class="fade-in">
-                    <div class="glass-card bg-red-900/20 border-l-4 border-red-400">
-                        <p class="font-bold text-lg mb-2">
-                            <i class="fas fa-times-circle text-red-400 mr-2"></i>
-                            谎言："孩子的肠胃天生脆弱"
-                        </p>
-                        <p class="text-secondary">需要特别"调理"才能健康</p>
-                    </div>
-                    <div class="glass-card bg-green-900/20 border-l-4 border-green-400 mt-2">
-                        <p class="font-bold text-lg mb-2">
-                            <i class="fas fa-check-circle text-green-400 mr-2"></i>
-                            真相：6个月后消化系统已基本成熟
-                        </p>
-                        <p>
-                            <span class="highlight">是你的过度保护让它变得脆弱</span>，
-                            不是它天生脆弱！
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
+      button.addEventListener('pointerdown', () => {
+        holdTimer = setTimeout(() => {
+          triggerSpell(true);
+          holdTimer = null;
+        }, 600);
+      });
 
-    <!-- Section 6: 致命闭环 -->
-    <section class="section-padding py-20 px-6 bg-gray-900">
-        <div class="max-w-4xl mx-auto">
-            <div class="fade-in text-center mb-12">
-                <h2 class="text-3xl md:text-4xl font-black mb-6">
-                    你正在制造的<br>
-                    <span class="text-red-400">"致命闭环"</span>
-                </h2>
-            </div>
-            
-            <div class="fade-in">
-                <div class="relative w-64 h-64 mx-auto">
-                    <svg class="vortex w-full h-full" viewBox="0 0 256 256">
-                        <defs>
-                            <linearGradient id="vortexGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                                <stop offset="0%" style="stop-color:#ef4444;stop-opacity:0.8" />
-                                <stop offset="100%" style="stop-color:#dc2626;stop-opacity:1" />
-                            </linearGradient>
-                        </defs>
-                        <path d="M128,32 Q224,128 128,224 Q32,128 128,32" 
-                              fill="none" 
-                              stroke="url(#vortexGradient)" 
-                              stroke-width="3"/>
-                        <text x="128" y="60" text-anchor="middle" fill="#ef4444" font-size="14" font-weight="bold">限制饮食</text>
-                        <text x="200" y="128" text-anchor="middle" fill="#ef4444" font-size="14" font-weight="bold">消化退化</text>
-                        <text x="128" y="200" text-anchor="middle" fill="#ef4444" font-size="14" font-weight="bold">更加虚弱</text>
-                        <text x="56" y="128" text-anchor="middle" fill="#ef4444" font-size="14" font-weight="bold">更严格限制</text>
-                    </svg>
-                </div>
-                
-                <div class="text-center mt-8">
-                    <p class="text-xl font-bold text-red-400">
-                        越调理越虚弱，越虚弱越调理
-                    </p>
-                    <p class="text-lg mt-4">
-                        这是一个你亲手制造的死循环！
-                    </p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Section 7: 生长曲线 -->
-    <section class="section-padding py-20 px-6">
-        <div class="max-w-4xl mx-auto">
-            <div class="fade-in text-center mb-12">
-                <h2 class="text-3xl md:text-4xl font-black mb-6">
-                    直面真相：<br>
-                    <span class="text-orange-400">你的孩子在哪里？</span>
-                </h2>
-            </div>
-            
-            <div class="glass-card fade-in">
-                <div class="mb-6" style="height: 400px;">
-                    <canvas id="growthChart"></canvas>
-                </div>
-                <div class="grid md:grid-cols-3 gap-4">
-                    <input type="number" id="childAge" placeholder="孩子年龄 (2-18岁)" 
-                           class="bg-gray-800 text-white p-3 rounded-lg border border-gray-700 focus:border-blue-400">
-                    <input type="number" id="childWeight" placeholder="孩子体重 (kg)" 
-                           class="bg-gray-800 text-white p-3 rounded-lg border border-gray-700 focus:border-blue-400">
-                    <button onclick="updateChart()" class="btn-primary">
-                        查看孩子的位置
-                    </button>
-                </div>
-                <p class="text-sm text-gray-500 mt-4">
-                    * 数据来源：WHO儿童生长标准
-                </p>
-            </div>
-        </div>
-    </section>
-
-    <!-- Section 8: 解决方案 -->
-    <section class="section-padding py-20 px-6 bg-gradient-to-b from-gray-900 to-black">
-        <div class="max-w-4xl mx-auto">
-            <div class="fade-in text-center mb-12">
-                <h2 class="text-3xl md:text-4xl font-black mb-6">
-                    从"胃修理工"到<br>
-                    <span class="text-green-400">"肠道园丁"</span>
-                </h2>
-            </div>
-            
-            <div class="narrator-card fade-in bg-green-900/20 border-green-400">
-                <p class="text-xl font-bold mb-4">妈妈，是时候改变了！</p>
-                <p class="mb-4">
-                    把自己想象成一个园丁，而不是修理工。
-                    孩子的肠道是一个美丽的花园，需要：
-                </p>
-                <ul class="space-y-2">
-                    <li>🌱 <strong>多样的种子</strong>（各种食物）</li>
-                    <li>💧 <strong>适当的浇水</strong>（均衡营养）</li>
-                    <li>☀️ <strong>阳光雨露</strong>（快乐进餐）</li>
-                    <li>🌿 <strong>自然生长</strong>（相信身体智慧）</li>
-                </ul>
-            </div>
-            
-            <div class="fade-in mt-12 text-center">
-                <img src="https://images.pexels.com/photos/1072824/pexels-photo-1072824.jpeg?auto=compress&cs=tinysrgb&w=1200" 
-                     alt="繁茂的花园" 
-                     class="hero-image mx-auto mb-6">
-                <p class="text-2xl font-bold text-green-400">
-                    这，才是你该为孩子打造的未来
-                </p>
-            </div>
-        </div>
-    </section>
-
-    <!-- Section 9: AI营养师 -->
-    <section class="section-padding py-20 px-6">
-        <div class="max-w-4xl mx-auto">
-            <div class="fade-in text-center mb-12">
-                <h2 class="text-3xl md:text-4xl font-black mb-6">
-                    AI营养师<br>
-                    <span class="text-orange-400">为你定制勇敢餐单</span>
-                </h2>
-                <p class="text-xl text-secondary">
-                    告诉我们孩子的情况，让科学帮你迈出第一步
-                </p>
-            </div>
-            
-            <div class="glass-card fade-in">
-                <div class="space-y-4">
-                    <div>
-                        <label class="block mb-2 font-semibold">
-                            孩子常吃的"安全"食物（用逗号分隔）
-                        </label>
-                        <input type="text" id="safeFoods" 
-                               placeholder="例如：米饭, 面条, 鸡蛋羹" 
-                               class="w-full bg-gray-800 text-white p-3 rounded-lg border border-gray-700 focus:border-orange-400">
-                    </div>
-                    <div>
-                        <label class="block mb-2 font-semibold">
-                            你不敢给孩子吃的"挑战"食物（用逗号分隔）
-                        </label>
-                        <input type="text" id="challengeFoods" 
-                               placeholder="例如：香蕉, 牛奶, 鱼" 
-                               class="w-full bg-gray-800 text-white p-3 rounded-lg border border-gray-700 focus:border-orange-400">
-                    </div>
-                    <button onclick="generateMealPlan()" class="btn-primary w-full text-lg py-4">
-                        <i class="fas fa-magic mr-2"></i>
-                        生成专属勇敢餐单
-                    </button>
-                </div>
-                
-                <div id="loader" class="hidden">
-                    <div class="loader"></div>
-                    <p class="text-center text-secondary">AI营养师正在为您定制方案...</p>
-                </div>
-                
-                <div id="planResult" class="mt-6"></div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Section 10: 最终承诺 -->
-    <section class="section-padding py-20 px-6 bg-gradient-to-b from-black to-gray-900">
-        <div class="max-w-4xl mx-auto text-center">
-            <div class="fade-in">
-                <h2 class="text-3xl md:text-4xl font-black mb-8">
-                    妈妈，你的抉择<br>
-                    <span class="text-orange-400">就是孩子的未来</span>
-                </h2>
-                
-                <div class="narrator-card bg-orange-900/20 border-orange-400 max-w-2xl mx-auto mb-8">
-                    <p class="text-lg mb-4">亲爱的妈妈：</p>
-                    <p class="mb-4">
-                        我知道改变很难，我知道你会害怕。
-                        但请相信，孩子的身体比你想象的更强大、更智慧。
-                    </p>
-                    <p class="mb-4">
-                        他们需要的不是"调理"，而是机会——
-                        一个自由生长、充分发育的机会。
-                    </p>
-                    <p class="text-xl font-bold text-orange-400">
-                        真正的爱，是相信，而不是限制。
-                    </p>
-                </div>
-                
-                <button onclick="makeCommitment()" class="btn-primary text-xl py-4 px-8">
-                    我要成为孩子的"肠道园丁"
-                </button>
-                
-                <p class="mt-6 text-secondary">
-                    已有 <span class="font-bold text-orange-400">87,432</span> 位妈妈做出了改变
-                </p>
-            </div>
-        </div>
-    </section>
-
-    <!-- Footer -->
-    <footer class="py-8 px-6 text-center text-gray-500 text-sm">
-        <p>为了孩子的未来，让我们一起努力 ❤️</p>
-        <p class="mt-2">© 2025 肠道花园计划 - 科学育儿，健康成长</p>
-    </footer>
-
-    <script>
-        // 淡入动画
-        const observerOptions = {
-            threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
-        };
-
-        const observer = new IntersectionObserver((entries) => {
-            entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                    entry.target.classList.add('visible');
-                }
-            });
-        }, observerOptions);
-
-        document.querySelectorAll('.fade-in').forEach(el => {
-            observer.observe(el);
+      ['pointerup', 'pointerleave', 'pointercancel'].forEach((event) => {
+        button.addEventListener(event, () => {
+          if (holdTimer) {
+            clearTimeout(holdTimer);
+            triggerSpell(false);
+          }
+          holdTimer = null;
         });
+      });
 
-        // 生长曲线图表
-        let growthChart = null;
-        
-        function initGrowthChart() {
-            const ctx = document.getElementById('growthChart').getContext('2d');
-            
-            // 2-18岁的数据
-            const ageLabels = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18];
-            const normalWeight = [12.5, 14.5, 16.5, 18.5, 20.5, 23, 26, 29, 33, 37, 42, 47, 52, 56, 59, 61, 62];
-            const warningWeight = [11, 12.5, 14, 15.5, 17, 19, 21.5, 24, 27, 30.5, 34.5, 38.5, 42.5, 46, 48.5, 50, 51];
-            
-            growthChart = new Chart(ctx, {
-                type: 'line',
-                data: {
-                    labels: ageLabels,
-                    datasets: [
-                        {
-                            label: '理想体重轨迹',
-                            data: normalWeight,
-                            borderColor: '#22c55e',
-                            backgroundColor: 'rgba(34, 197, 94, 0.1)',
-                            borderWidth: 3,
-                            fill: true,
-                            tension: 0.4
-                        },
-                        {
-                            label: '营养不良警戒线',
-                            data: warningWeight,
-                            borderColor: '#ef4444',
-                            backgroundColor: 'rgba(239, 68, 68, 0.1)',
-                            borderWidth: 2,
-                            borderDash: [5, 5],
-                            fill: '-1',
-                            tension: 0.4
-                        },
-                        {
-                            label: '您孩子的位置',
-                            data: [],
-                            borderColor: '#f97316',
-                            backgroundColor: '#f97316',
-                            pointRadius: 10,
-                            pointHoverRadius: 12,
-                            showLine: false
-                        }
-                    ]
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    plugins: {
-                        legend: {
-                            labels: {
-                                color: '#e5e7eb',
-                                font: { size: 14 }
-                            }
-                        },
-                        title: {
-                            display: true,
-                            text: '儿童体重生长曲线（2-18岁）',
-                            color: '#e5e7eb',
-                            font: { size: 16 }
-                        }
-                    },
-                    scales: {
-                        x: {
-                            title: {
-                                display: true,
-                                text: '年龄（岁）',
-                                color: '#9ca3af'
-                            },
-                            grid: { color: 'rgba(156, 163, 175, 0.2)' },
-                            ticks: { color: '#9ca3af' }
-                        },
-                        y: {
-                            title: {
-                                display: true,
-                                text: '体重（kg）',
-                                color: '#9ca3af'
-                            },
-                            grid: { color: 'rgba(156, 163, 175, 0.2)' },
-                            ticks: { color: '#9ca3af' },
-                            min: 10,
-                            max: 65
-                        }
-                    }
-                }
-            });
+      return card;
+    }
+
+    function createTierIV(panel) {
+      const card = document.createElement('div');
+      card.className = 'tier-card';
+      card.innerHTML = `
+        <h4>Tier IV · 方法秘笈</h4>
+        <div class="ugc-card">
+          <strong>${panel.tierIV.methodTitle}</strong>
+          <ol class="method-list">
+            ${panel.tierIV.bullets.map((item) => `<li>${item}</li>`).join('')}
+          </ol>
+        </div>
+      `;
+      return card;
+    }
+
+    function createTierV(panel) {
+      const card = document.createElement('div');
+      card.className = 'tier-card';
+      const progress = Math.min(100, Math.max(0, panel.tierV.mrd7.progress));
+      card.innerHTML = `
+        <h4>Tier V · 迁移与成就</h4>
+        <div class="badge-row">
+          <div class="badge">MRD7 · ${panel.tierV.mrd7.dimension}</div>
+          <div>
+            <div>${panel.tierV.mrd7.note}</div>
+            <div class="progress-bar" aria-hidden="true"><span style="width: ${progress}%"></span></div>
+          </div>
+        </div>
+        <div class="ugc-card" style="margin-top:16px;">
+          <strong>${panel.tierV.ugcTask.title}</strong>
+          <p style="margin:12px 0 6px;">${panel.tierV.ugcTask.prompt}</p>
+          <div style="font-size:0.9rem;color:var(--text-sub);">${panel.tierV.ugcTask.tip}</div>
+        </div>
+      `;
+      return card;
+    }
+
+    function highlightSentence(sentence, cards) {
+      let result = sentence;
+      cards.forEach(({ word }) => {
+        const pattern = new RegExp(`\\[\\[${word}\\]\\]`, 'gi');
+        result = result.replace(pattern, `<span class="word" data-word="${word.toLowerCase()}">${word}</span>`);
+      });
+      return result.replace(/\\[\\[|\\]\\]/g, '');
+    }
+
+    function attachWordCards(dialogue, cards) {
+      const map = new Map(cards.map((card) => [card.word.toLowerCase(), card]));
+      dialogue.querySelectorAll('.word').forEach((wordEl) => {
+        wordEl.addEventListener('click', () => {
+          const data = map.get(wordEl.dataset.word);
+          if (!data) return;
+          metrics.interact += 1;
+          metrics.speak += 1;
+          updateMetrics();
+          openWordCard(data);
+        });
+      });
+    }
+
+    function openWordCard(data) {
+      cardWord.textContent = data.word;
+      cardIpa.textContent = data.ipa;
+      cardTranslation.textContent = `释义：${data.translation}`;
+      cardExamples.innerHTML = data.examples.map((ex) => `<li>${ex}</li>`).join('');
+      wordLayer.style.display = 'flex';
+      wordLayer.setAttribute('aria-hidden', 'false');
+    }
+
+    function closeWordCard() {
+      wordLayer.style.display = 'none';
+      wordLayer.setAttribute('aria-hidden', 'true');
+    }
+
+    closeCardBtn.addEventListener('click', closeWordCard);
+    wordLayer.addEventListener('click', (e) => {
+      if (e.target === wordLayer) {
+        closeWordCard();
+      }
+    });
+
+    function attachLongPress(dialogue, hint) {
+      let timer = null;
+      const showTranslation = () => {
+        hint.style.display = 'block';
+        metrics.interact += 1;
+        updateMetrics();
+      };
+
+      dialogue.addEventListener('pointerdown', () => {
+        timer = setTimeout(showTranslation, 500);
+      });
+
+      const clear = () => {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
         }
+      };
 
-        // 初始化图表
-        window.addEventListener('load', initGrowthChart);
+      ['pointerup', 'pointerleave', 'pointercancel'].forEach((event) => {
+        dialogue.addEventListener(event, clear);
+      });
+    }
 
-        // 更新图表
-        function updateChart() {
-            const age = parseFloat(document.getElementById('childAge').value);
-            const weight = parseFloat(document.getElementById('childWeight').value);
-            
-            if (!age || !weight || age < 2 || age > 18) {
-                alert('请输入有效的年龄（2-18岁）和体重');
-                return;
+    function observeVisibility(section, id) {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              section.classList.add('visible');
+              metrics.viewedPanels.add(id);
+              updateCompletion();
             }
+          });
+        },
+        { threshold: 0.4 }
+      );
+      observer.observe(section);
+    }
 
-            if (growthChart) {
-                growthChart.data.datasets[2].data = [{x: age, y: weight}];
-                growthChart.update();
-                
-                // 显示解释
-                const normalWeight = [12.5, 14.5, 16.5, 18.5, 20.5, 23, 26, 29, 33, 37, 42, 47, 52, 56, 59, 61, 62];
-                const warningWeight = [11, 12.5, 14, 15.5, 17, 19, 21.5, 24, 27, 30.5, 34.5, 38.5, 42.5, 46, 48.5, 50, 51];
-                const index = Math.floor(age) - 2;
-                
-                if (index >= 0 && index < normalWeight.length) {
-                    let message = '';
-                    if (weight < warningWeight[index]) {
-                        message = '⚠️ 警告：您的孩子体重严重偏低，已低于营养不良警戒线！';
-                    } else if (weight < normalWeight[index] * 0.9) {
-                        message = '⚠️ 注意：您的孩子体重偏低，需要改善营养状况。';
-                    } else {
-                        message = '✓ 您的孩子体重在正常范围内，继续保持均衡饮食！';
-                    }
-                    
-                    setTimeout(() => alert(message), 100);
-                }
-            }
-        }
+    function updateMetrics() {
+      metricSpeak.textContent = metrics.speak;
+      metricInteract.textContent = metrics.interact;
+    }
 
-        // AI餐单生成（模拟）
-        function generateMealPlan() {
-            const safeFoods = document.getElementById('safeFoods').value;
-            const challengeFoods = document.getElementById('challengeFoods').value;
-            
-            if (!safeFoods || !challengeFoods) {
-                alert('请填写完整的食物信息');
-                return;
-            }
-            
-            const loader = document.getElementById('loader');
-            const resultDiv = document.getElementById('planResult');
-            
-            loader.classList.remove('hidden');
-            resultDiv.innerHTML = '';
-            
-            // 模拟API调用
-            setTimeout(() => {
-                const safeFoodList = safeFoods.split(',').map(f => f.trim());
-                const challengeFoodList = challengeFoods.split(',').map(f => f.trim());
-                
-                const plan = `
-                    <div class="glass-card bg-green-900/20 border-l-4 border-green-400 mt-6">
-                        <h3 class="text-xl font-bold text-green-400 mb-4">
-                            您的专属3日勇敢餐单
-                        </h3>
-                        
-                        <div class="space-y-4">
-                            <div>
-                                <h4 class="font-bold text-orange-400">第一天：温柔的开始</h4>
-                                <p class="text-sm mb-2">早餐：${safeFoodList[0]} + 一小勺${challengeFoodList[0]}泥</p>
-                                <p class="text-sm mb-2">午餐：${safeFoodList[1] || safeFoodList[0]} + 常规配菜</p>
-                                <p class="text-sm mb-2">晚餐：${safeFoodList[2] || safeFoodList[0]} + 蔬菜</p>
-                                <p class="text-sm text-gray-400">
-                                    💡 今天只是让孩子"认识"${challengeFoodList[0]}，即使只是看看、闻闻也是进步！
-                                </p>
-                            </div>
-                            
-                            <div>
-                                <h4 class="font-bold text-orange-400">第二天：小小的尝试</h4>
-                                <p class="text-sm mb-2">早餐：${safeFoodList[0]} + 两小勺${challengeFoodList[0]}</p>
-                                <p class="text-sm mb-2">午餐：${safeFoodList[1] || safeFoodList[0]} + 一点点${challengeFoodList[1] || challengeFoodList[0]}</p>
-                                <p class="text-sm mb-2">晚餐：熟悉的晚餐</p>
-                                <p class="text-sm text-gray-400">
-                                    💡 如果孩子愿意尝一口，记得温柔地鼓励，但不要过度表扬。
-                                </p>
-                            </div>
-                            
-                            <div>
-                                <h4 class="font-bold text-orange-400">第三天：建立信心</h4>
-                                <p class="text-sm mb-2">早餐：可以尝试让${challengeFoodList[0]}成为早餐的一部分</p>
-                                <p class="text-sm mb-2">午餐：继续昨天的组合，稍微增加分量</p>
-                                <p class="text-sm mb-2">晚餐：${safeFoodList[0]} + 新的蔬菜尝试</p>
-                                <p class="text-sm text-gray-400">
-                                    💡 三天后，孩子可能已经接受了新食物。记住：这不是结束，而是开始！
-                                </p>
-                            </div>
-                        </div>
-                        
-                        <div class="mt-4 p-4 bg-orange-900/20 rounded-lg">
-                            <p class="font-bold text-orange-400 mb-2">记住园丁的智慧：</p>
-                            <p class="text-sm">
-                                • 保持轻松愉快的用餐氛围<br>
-                                • 每次只引入一种新食物<br>
-                                • 相信孩子的身体智慧<br>
-                                • 庆祝每一个小进步
-                            </p>
-                        </div>
-                    </div>
-                `;
-                
-                resultDiv.innerHTML = plan;
-                loader.classList.add('hidden');
-            }, 2000);
-        }
-
-        // 最终承诺
-        function makeCommitment() {
-            const confirmed = confirm(
-                '我承诺：\n\n' +
-                '我将相信孩子的身体智慧，\n' +
-                '不再用恐惧限制孩子的饮食，\n' +
-                '我要成为孩子肠道花园的园丁，\n' +
-                '让TA自由、健康、快乐地成长！\n\n' +
-                '点击"确定"加入肠道花园计划'
-            );
-            
-            if (confirmed) {
-                alert(
-                    '🎉 恭喜你，勇敢的妈妈！\n\n' +
-                    '你已经迈出了最重要的一步。\n' +
-                    '记住，改变需要时间，但你不是一个人。\n\n' +
-                    '让我们一起，为孩子创造一个更健康的未来！'
-                );
-            }
-        }
-    </script>
+    function updateCompletion() {
+      const completion = metrics.totalPanels ? Math.round((metrics.viewedPanels.size / metrics.totalPanels) * 100) : 0;
+      metricComplete.textContent = `${completion}%`;
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the previous landing page with an MVLU-focused preview site that explains the story-driven learning MVP and live NSE/NSD counters
- add interactive Tier II keyword cards, Tier III spell casting simulation, and Tier IV/V method plus UGC panels driven by JSON data
- introduce an `assets/m1-panels.json` contract for P01-P03 of M1《昨夜的证词》 to standardize narrative, teaching, and visual prompts

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ce2104abdc8322ac5bf0f740a06f60